### PR TITLE
Fix progress report listing for voting

### DIFF
--- a/Frontend/src/Components/VotingCard/index.js
+++ b/Frontend/src/Components/VotingCard/index.js
@@ -93,7 +93,7 @@ const VotingCard = ({
     //     }
     // );
     fetchRemainingVotesRequest({
-      type: 'progress_report',
+      type: 'progress_reports',
     });
   }, [selectedTab, pageNumber, fetchRemainingVotesRequest]);
 

--- a/Frontend/src/Redux/ICON/EventHandler/index.js
+++ b/Frontend/src/Redux/ICON/EventHandler/index.js
@@ -435,7 +435,7 @@ export default event => {
               });
               store.dispatch(
                 fetchRemainingVotesRequest({
-                  type: 'progress_report',
+                  type: 'progress_reports',
                 }),
               );
               return true;

--- a/Frontend/src/Redux/Sagas/PRep/fetchPrepsWithStatsWorker.js
+++ b/Frontend/src/Redux/Sagas/PRep/fetchPrepsWithStatsWorker.js
@@ -35,7 +35,7 @@ function* fetchPrepsWithStatsWorker({ payload }) {
         method: 'get_remaining_project',
         params: {
           _wallet_address: prep.address,
-          _project_type: 'progress_report',
+          _project_type: 'progress_reports',
         },
       });
 


### PR DESCRIPTION
fix `project_type` at getRemainingProject for progress report from `progress_report` to `progress_reports` after contract upgrade